### PR TITLE
Remove forced sudo

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sudo /bin/sh
+#!/bin/sh
 
 SUPERAPP="superuser"
 ADBBINARY="adb.linux"


### PR DESCRIPTION
A script should not default to sudo globally. Root rights have to be used as little as possible, not everyone uses sudo with global rights (so script might not work at all), and here it's actually mostly unnecessary.

In this case, root rights are mostly needed to access the device through adb, therefor 2 options should be possible. First: user has the necessary udev rules set up to be able to work with his device in a non-root environment, maybe from an android development environment or just manually installed because of being an avid flasher, IDK, and therefor running this script as sudo is unnecessary and s/he should not be forced to. Second: user doesn't have any rules set up, and in this case the script could be invoked with sudo manually or completely run as root, depending on the configuration, and again it's not necessary to force it.

I don't know how OSX would be affected, but I'm quite sure it can work the same way.

Otherwise: just installed it (with the change I'm proposing) and I'm really impressed with your work, xNUTx. Thank you very much!
